### PR TITLE
Alternative way to install Nodesource repo with curl.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Add a list of npm packages with a `name` and (optional) `version` to be installe
       # Install the latest stable release of a package.
       - name: node-sass
 
-Set to false to install the Nodesource repository using the rpm_key and yum modules, instead of using curl and importing the files directly. May fail due to SNI issues with CloudFront.
+Set to true to download the gpg and rpm files with curl, instead of importing them through rpm_key/yum directly. Use only when you are encountering SNI issues with Nodesource.
 
-    curl_nodesource_rpm: true
+    curl_nodesource_rpm: false
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Add a list of npm packages with a `name` and (optional) `version` to be installe
       # Install the latest stable release of a package.
       - name: node-sass
 
+Set to false to install the Nodesource repository using the rpm_key and yum modules, instead of using curl and importing the files directly. May fail due to SNI issues with CloudFront.
+
+    curl_nodesource_rpm: true
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,3 +19,7 @@ nodejs_npm_global_packages: []
 #    version: 0.9.3
 #  # Install the latest stable release of a package.
 #  - name: node-sass
+
+# Import the Noesource RPM key by downloading with curl instead of using the rpm_key module directly, and then install the rpm file using curl and the yum module.
+curl_nodesource_rpm: true
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,6 @@ nodejs_npm_global_packages: []
 #  # Install the latest stable release of a package.
 #  - name: node-sass
 
-# Import the Noesource RPM key by downloading with curl instead of using the rpm_key module directly, and then install the rpm file using curl and the yum module.
-curl_nodesource_rpm: true
+# Import the Nodesource RPM key by downloading with curl instead of using the rpm_key module directly, and then install the rpm file using curl and the yum module.
+curl_nodesource_rpm: false
 

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -9,13 +9,13 @@
     nodejs_rhel_rpm_dir: "pub"
   when: nodejs_version == '0.10'
 
-- name: Import Nodesource RPM key over https.
+- name: Import Nodesource RPM key with rpm_key directly.
   rpm_key:
     key: https://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL
     state: present
   when: not curl_nodesource_rpm
 
-- name: Download Nodesource RPM key with Curl
+- name: Download Nodesource RPM key with Curl.
   shell: curl https://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL -o /tmp/nodesource.gpg
   args:
     creates: /tmp/nodesource.gpg
@@ -29,12 +29,19 @@
 
 - name: Add Nodesource repositories for Node.js.
   yum:
-    name: "https://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"
+    name: >
+      https://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/
+      {{ ansible_distribution_major_version }}/{{ ansible_architecture }}/
+      nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm
     state: present
   when: not curl_nodesource_rpm
 
 - name: Download Nodesource rpm file for Node.js.
-  shell: "curl https://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm -o /tmp/nodesource.rpm"
+  shell: >
+    curl https://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/
+    {{ ansible_distribution_major_version }}/{{ ansible_architecture }}/
+    nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm
+    -o /tmp/nodesource.rpm
   args:
     creates: /tmp/nodesource.rpm
   when: curl_nodesource_rpm

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -9,15 +9,41 @@
     nodejs_rhel_rpm_dir: "pub"
   when: nodejs_version == '0.10'
 
-- name: Import Nodesource RPM key.
+- name: Import Nodesource RPM key over https.
   rpm_key:
     key: https://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL
     state: present
+  when: not curl_nodesource_rpm
+
+- name: Download Nodesource RPM key with Curl
+  shell: curl https://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL -o /tmp/nodesource.gpg
+  args:
+    creates: /tmp/nodesource.gpg
+  when: curl_nodesource_rpm
+
+- name: Import Nodesource RPM key from file. 
+  rpm_key:
+    key: /tmp/nodesource.gpg
+    state: present
+  when: curl_nodesource_rpm
 
 - name: Add Nodesource repositories for Node.js.
   yum:
     name: "https://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"
     state: present
+  when: not curl_nodesource_rpm
+
+- name: Download Nodesource rpm file for Node.js.
+  shell: "curl https://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm -o /tmp/nodesource.rpm"
+  args:
+    creates: /tmp/nodesource.rpm
+  when: curl_nodesource_rpm
+
+- name: Add Nodesource repositories from rpm file.
+  yum:
+    name: /tmp/nodesource.rpm
+    state: present
+  when: curl_nodesource_rpm
 
 - name: Ensure Node.js and npm are installed.
   yum: "name=nodejs-{{ nodejs_version[0] }}.* state=present enablerepo='epel,nodesource'"


### PR DESCRIPTION
**_Defect_**

## Summary of changes

- Introduce alternative way to install Nodesource repo by downloading the needed files (`gpg` key and `rpm` file) with curl, instead of using the `rpm_key` and `yum` Ansible modules directly. This is a workaround to the SNI issue introduced when Nodesource moved to CloudFront.
  - Add `curl_nodesource_rpm` variable (default: `true`) which does the above. If set to `false`, the keyfile and repo files are downloaded directly over HTTPS

/fyi: @tjoelsson, @mark-juwai: Please review.
