### PR TITLE
Fix whitespaces appearing in multiline string

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -29,19 +29,17 @@
 
 - name: Add Nodesource repositories for Node.js.
   yum:
-    name: >
-      https://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/
-      {{ ansible_distribution_major_version }}/{{ ansible_architecture }}/
-      nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm
+    name: "https://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/\
+      {{ ansible_distribution_major_version }}/{{ ansible_architecture }}/\
+      nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"
     state: present
   when: not curl_nodesource_rpm
 
 - name: Download Nodesource rpm file for Node.js.
-  shell: >
-    curl https://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/
-    {{ ansible_distribution_major_version }}/{{ ansible_architecture }}/
-    nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm
-    -o /tmp/nodesource.rpm
+  shell: "curl https://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/\
+      {{ ansible_distribution_major_version }}/{{ ansible_architecture }}/\
+      nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm \
+      -o /tmp/nodesource.rpm"
   args:
     creates: /tmp/nodesource.rpm
   when: curl_nodesource_rpm


### PR DESCRIPTION
Changed the multi-line string strategy from `>` to a double-quote wrapped string with escaped new space.