### PR TITLE
Fix RPM 404 error in Nodesource

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -29,14 +29,14 @@
 
 - name: Add Nodesource repositories for Node.js.
   yum:
-    name: "https://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/\
+    name: "https://rpm.nodesource.com/pub/el/\
       {{ ansible_distribution_major_version }}/{{ ansible_architecture }}/\
       nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"
     state: present
   when: not curl_nodesource_rpm
 
 - name: Download Nodesource rpm file for Node.js.
-  shell: "curl https://rpm.nodesource.com/{{ nodejs_rhel_rpm_dir }}/el/\
+  shell: "curl https://rpm.nodesource.com/pub/el/\
       {{ ansible_distribution_major_version }}/{{ ansible_architecture }}/\
       nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm \
       -o /tmp/nodesource.rpm"

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,14 +1,4 @@
 ---
-- name: Set up the Nodesource RPM directory for Node.js > 0.10.
-  set_fact:
-    nodejs_rhel_rpm_dir: "pub_{{ nodejs_version }}"
-  when: nodejs_version != '0.10'
-
-- name: Set up the Nodesource RPM variable for Node.js == 0.10.
-  set_fact:
-    nodejs_rhel_rpm_dir: "pub"
-  when: nodejs_version == '0.10'
-
 - name: Import Nodesource RPM key with rpm_key directly.
   rpm_key:
     key: https://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL


### PR DESCRIPTION
Remove `{{ nodejs_rhel_rpm_dir }}` variable (which evaluates to `pub_0.12/` and causes a 404 error, and just use the `pub/` folder directly.